### PR TITLE
fix: unset noCursorTimeout set by mongo driver

### DIFF
--- a/adapter.js
+++ b/adapter.js
@@ -163,7 +163,11 @@ export function adapter(client) {
     const getDb = tryCatch((db) => client.database(db).collection(db));
     return resultToAsync(getDb(db))
       .chain(checkIfDbExists(db))
-      .chain((db) => findOne(db)({ _id: id }))
+      .chain((db) =>
+        findOne(db)({ _id: id }, {
+          noCursorTimeout: undefined,
+        })
+      )
       .chain((doc) =>
         doc !== undefined
           ? Async.Resolved(doc)
@@ -223,7 +227,10 @@ export function adapter(client) {
   async function queryDocuments({ db, query }) {
     try {
       const m = client.database(db).collection(db);
-      const docs = await m.find(query.selector, queryOptions(query)).toArray();
+      const docs = await m.find(query.selector, {
+        ...queryOptions(query),
+        noCursorTimeout: undefined,
+      }).toArray();
       return { ok: true, docs: map(swap("_id", "id"), docs) };
     } catch (e) {
       console.log(e);
@@ -262,7 +269,10 @@ export function adapter(client) {
         : options;
 
       const m = client.database(db).collection(db);
-      const docs = await m.find(q, options).toArray();
+      const docs = await m.find(q, {
+        ...options,
+        noCursorTimeout: undefined,
+      }).toArray();
 
       return { ok: true, docs: map(swap("_id", "id"), docs) };
     } catch (e) {


### PR DESCRIPTION
Closes #19 

I am inclined to make this more comprehensive, like maybe adding a
"documentDb" mode or perhaps forking this adapter
into a DocumentDB adapter, but seems like overkill for overriding a flag
that hyper intentionally doesn't take advantage of anyway. The only way
I could see this biting us is if the mongo driver does
something like recycling cursor objects. I'm not sure if it does